### PR TITLE
Adding other umask parameters supported by WinFsp

### DIFF
--- a/src/renderer/SshfsParamsList.js
+++ b/src/renderer/SshfsParamsList.js
@@ -268,5 +268,15 @@ export default [
     name: 'to_code',
     type: 'string',
     description: 'New encoding of the file names (default: ISO-8859-2)'
+  },
+  {
+    name: 'create_file_umask',
+    type: 'number',
+    description: 'New file permissions (octal)'
+  },
+  {
+    name: 'create_dir_umask',
+    type: 'number',
+    description: 'New directory permissions (octal)'
   }
 ]


### PR DESCRIPTION
[WinFsp 2019.3](https://github.com/billziss-gh/winfsp/releases/tag/v1.5) added a few extra parameters to help deal with some `create_umask` issues when creating files/directories. This PR just adds those parameters to the list supported by the application.

For more information on the issue itself, see billziss-gh/winfsp#138, and billziss-gh/winfsp#227 for the solution.