### PR TITLE
Fix bug #106, key selection dialog did not work.

### DIFF
--- a/src/renderer/components/AddEditConnectionWindow/index.vue
+++ b/src/renderer/components/AddEditConnectionWindow/index.vue
@@ -144,8 +144,8 @@ export default {
         defaultPath: process.env.USERPROFILE + '\\.ssh\\'
       })
 
-      if (file) {
-        this.conn.keyFile = file
+      if (file && file.length > 0) {
+        this.conn.keyFile = file[0]
       }
     }
   },


### PR DESCRIPTION
Added a check for file length/size and an array to check that file.

Verified against manually selecting the id_rsa, and also browsing to other id_rsa.named files that exist in another folder. All worked properly.
Verified that failures still occur when unable to connect.
Did not verify a PEM file, which was the initial report since I do not have any PEMs to test against.