### PR TITLE
Fix name typo `uidfile` SSHFS Params List

### DIFF
--- a/src/renderer/SshfsParamsList.js
+++ b/src/renderer/SshfsParamsList.js
@@ -60,7 +60,7 @@ export default [
     description: 'User/group ID mapping'
   },
   {
-    name: 'oidfile',
+    name: 'uidfile',
     type: 'string',
     description: 'File containing username:uid mappings for idmap=file'
   },


### PR DESCRIPTION
Fix param name typo in SSHFS Params List.
- `oidfile` => `uidfile`

When using parameter `idmap=file` SSHFS expects a file path for `uidfile` and/or `gidfile`.
Setting the option `oidfile` does not satisfy either options.

I believe this could partially resolve #209 as far as user mapping is the only cause.
Using private key files for auth and/or domain users could be another source for the issue, but that's unrelated to this PR.